### PR TITLE
Hooking into methods with a single parameter

### DIFF
--- a/src/patch/patch.zig
+++ b/src/patch/patch.zig
@@ -174,6 +174,15 @@ fn HookTextRender(memory: usize) usize {
     return mem.intercept_call(memory, 0x483F8B, null, &TextRender_Before);
 }
 
+// Texture intercepts
+fn SpriteLoading_Before(sprite: u32) void {
+    general.SpriteLoading_Before(sprite);
+}
+
+fn HookSpriteLoading(memory: usize) usize {
+    return mem.intercept_call_one_u32_param(memory, 0x446FB5, &SpriteLoading_Before);
+}
+
 // DO THE THING!!!
 
 export fn Patch() void {
@@ -196,6 +205,7 @@ export fn Patch() void {
     off = HookGameEnd(off);
     off = HookTextRender(off);
     off = HookMenuDrawing(off);
+    off = HookSpriteLoading(off);
 
     // init
 

--- a/src/patch/patch_general.zig
+++ b/src/patch/patch_general.zig
@@ -13,6 +13,7 @@ const rc = @import("util/racer_const.zig");
 const rf = @import("util/racer_fn.zig");
 
 const mem = @import("util/memory.zig");
+const msg = @import("util/message.zig");
 
 // dumping ground for random features i guess
 
@@ -113,5 +114,14 @@ pub fn EarlyEngineUpdate_Before() void {
 pub fn TextRender_Before() void {
     if (s.gen.get("rainbow_timer_enable", bool)) {
         PatchHudTimerColRotate();
+    }
+}
+
+pub fn SpriteLoading_Before(sprite: u32) void {
+    var buf: [127:0]u8 = undefined;
+    _ = std.fmt.bufPrintZ(&buf, "~f0~sLoading Sprite{d}", .{sprite}) catch unreachable;
+    rf.swrText_CreateEntry1(100, 200, 255, 255, 255, 190, &buf);
+    if (false) {
+        msg.Message("Sprite {d}", .{sprite}, "Sprites SWE1R...", .{});
     }
 }


### PR DESCRIPTION
This is a proof of concept for hooking into a method of a single parameter

It allows at runtime to insert a function that takes a single parameter, and then saves that parameter in the right place in the stack to call the function

This allows inserting another function with a single parameter, that will enable you to look at that value

This works by creating a stack frame, and then looking at the top of the stack for the variable that was passed in, inserting that back on top of the stack and then restoring the stack frame - so we can call a function before the other one executes