### PR TITLE
Add collision viewer depth bias to settings.ini

### DIFF
--- a/src/patch/core/Settings.zig
+++ b/src/patch/core/Settings.zig
@@ -43,6 +43,7 @@ pub const SettingsState = struct {
     pub var qol: SettingsGroup = undefined;
     pub var cosmetic: SettingsGroup = undefined;
     pub var developer: SettingsGroup = undefined;
+    pub var collisionviewer: SettingsGroup = undefined;
 };
 
 fn get(group: ?[*:0]const u8, setting: [*:0]const u8, comptime T: type) ?T {
@@ -134,6 +135,10 @@ pub fn init() void {
     SettingsState.gameplay.add("death_speed_min", f32, 325);
     SettingsState.gameplay.add("death_speed_drop", f32, 140);
     SettingsState.manager.add(&SettingsState.gameplay);
+    
+    SettingsState.collisionviewer = SettingsGroup.init(alloc, "collisionviewer");
+    SettingsState.collisionviewer.add("depth_bias", i32, 10);
+    SettingsState.manager.add(&SettingsState.collisionviewer);
 
     SettingsState.developer = SettingsGroup.init(alloc, "developer");
     SettingsState.developer.add("dump_fonts", bool, false); // working?
@@ -221,4 +226,5 @@ pub fn OnDeinit(_: *GlobalSt, _: *GlobalFn) callconv(.C) void {
     defer SettingsState.qol.deinit();
     defer SettingsState.cosmetic.deinit();
     defer SettingsState.developer.deinit();
+    defer SettingsState.collisionviewer.deinit();
 }

--- a/src/patch/dll_collision_viewer.zig
+++ b/src/patch/dll_collision_viewer.zig
@@ -226,7 +226,7 @@ const QuickRaceMenu = extern struct {
         mi.MenuItemSpacer(),
         mi.MenuItemToggle(&QuickRaceMenu.item_depth_test.input_converted, "Depth test"),
         mi.MenuItemToggle(&QuickRaceMenu.item_cull_backfaces.input_converted, "Cull backfaces"),
-        mi.MenuItemRange(&QuickRaceMenu.item_depth_bias.input_converted, "Depth bias", 0, 100, false, null),
+        mi.MenuItemRange(&QuickRaceMenu.item_depth_bias.input_converted, "Depth bias", -100, 100, false, null),
     };
 
     var item_enabled = ConvertedMenuItem{ .input_bool = &state.enabled };
@@ -339,9 +339,17 @@ export fn PluginCompatibilityVersion() callconv(.C) u32 {
 extern fn init_collision_viewer(gs: *CollisionViewerState) callconv(.C) void;
 extern fn deinit_collision_viewer() callconv(.C) void;
 
-export fn OnInit(gs: *GlobalSt, gf: *GlobalFn) callconv(.C) void {
-    init_collision_viewer(&state);
+fn handle_settings(gf: *GlobalFn) callconv(.C) void {
+    var biasInt: i32 = gf.SettingGetI("collisionviewer", "depth_bias") orelse 10;
+    var biasFloat: f32 = @floatFromInt(biasInt);
+    state.depth_bias = biasFloat / 100.0;
+}
 
+export fn OnInit(gs: *GlobalSt, gf: *GlobalFn) callconv(.C) void {
+    handle_settings(gf);
+    
+    init_collision_viewer(&state);
+    
     QuickRaceMenu.gs = gs;
     QuickRaceMenu.gf = gf;
 }


### PR DESCRIPTION
For reasons still under investigation, the collision viewer's mesh can require different depth bias values to be rendered correctly, depending on the player's `ddraw.dll`, whether the player is using dgVoodoo, and potentially other system factors.

For the time being, allow the user to specify a depth bias in settings.ini to override the default value, and allow negative depth biases. On my system, a depth value around -.75 is needed to achieve the appropriate depth.